### PR TITLE
Convert TeamCity integration over to REST

### DIFF
--- a/lib/services/teamcity.rb
+++ b/lib/services/teamcity.rb
@@ -36,9 +36,9 @@ class Service::TeamCity < Service
 
       if check_for_changes_only
         # This is undocumented call. TODO: migrate to REST API (TC at least 8.0)
-        res = http_get "httpAuth/action.html", :checkForChangesBuildType => build_type_id
+        res = http_post "httpAuth/app/rest/vcs-root-instances/checkingForChangesQueue?locator=buildType:#{build_type_id}"
       else
-        res = http_get "httpAuth/action.html", :add2Queue => build_type_id, :branchName => branch
+        res = http_post "httpAuth/app/rest/buildQueue", "<build branchName=\"#{branch}\"><buildType id=\"#{build_type_id}\"></build>"
       end
 
       case res.status

--- a/test/teamcity_test.rb
+++ b/test/teamcity_test.rb
@@ -6,10 +6,18 @@ class TeamCityTest < Service::TestCase
   end
 
   def test_push
-    url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    url = "/abc/httpAuth/app/rest/buildQueue"
+    @stubs.post url do |env|
       assert_equal 'teamcity.com', env[:url].host
-      assert_equal 'btid', env[:params]['add2Queue']
+      assert_equal '<build branchName=""><buildType id="btid"></build>', env[:body]
+      assert_equal basic_auth(:u, :p), env[:request_headers]['authorization']
+      [200, {}, '']
+    end
+
+    url2 = "abc/httpAuth/app/rest/vcs-root-instances/checkingForChangesQueue?locator=buildType:btid"
+    @stubs.post url2 do |env|
+      assert_equal 'teamcity.com', env[:url].host
+      assert_equal nil, env[:body]
       assert_equal basic_auth(:u, :p), env[:request_headers]['authorization']
       [200, {}, '']
     end
@@ -26,7 +34,7 @@ class TeamCityTest < Service::TestCase
 
   def test_push_deleted_branch
     url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    @stubs.post url do |env|
       assert false, "service should not be called for deleted branches"
     end
 
@@ -41,9 +49,9 @@ class TeamCityTest < Service::TestCase
   end
 
   def test_push_with_branch_name
-    url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
-      assert_equal 'branch-name', env[:params]['branchName']
+    url = "/abc/httpAuth/app/rest/buildQueue"
+    @stubs.post url do |env|
+      assert_equal '<build branchName="branch-name"><buildType id="btid"></build>', env[:body]
       [200, {}, '']
     end
 
@@ -57,9 +65,9 @@ class TeamCityTest < Service::TestCase
   end
 
   def test_push_with_branch_name_incl_slashes
-    url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
-      assert_equal 'branch/name', env[:params]['branchName']
+    url = "/abc/httpAuth/app/rest/buildQueue"
+    @stubs.post url do |env|
+      assert_equal '<build branchName="branch/name"><buildType id="btid"></build>', env[:body]
       [200, {}, '']
     end
 
@@ -73,9 +81,9 @@ class TeamCityTest < Service::TestCase
   end
 
   def test_push_with_branch_full_ref
-    url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
-      assert_equal 'refs/heads/branch/name', env[:params]['branchName']
+    url = "/abc/httpAuth/app/rest/buildQueue"
+    @stubs.post url do |env|
+      assert_equal '<build branchName="refs/heads/branch/name"><buildType id="btid"></build>', env[:body]
       [200, {}, '']
     end
 
@@ -90,10 +98,10 @@ class TeamCityTest < Service::TestCase
   end
 
   def test_push_when_check_for_changes_is_true
-    url = "/abc/httpAuth/action.html"
-    @stubs.get url do |env|
+    url = "abc/httpAuth/app/rest/vcs-root-instances/checkingForChangesQueue?locator=buildType:btid"
+    @stubs.post url do |env|
       assert_equal 'teamcity.com', env[:url].host
-      assert_equal 'btid', env[:params]['checkForChangesBuildType']
+      assert_equal "", env[:body]
       [200, {}, '']
     end
 


### PR DESCRIPTION
This should fix the issue seen with the new version of TeamCity (2017.1
and 2017.1.1) where the httpauth/actions.html endpoint was deprecated.

Please note: GitHub will only accept pull requests to existing services that implement bug fixes or security improvements. We no longer accept feature changes to existing services.
